### PR TITLE
Convert image references into SVGs

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -9,7 +9,6 @@ export default Ember.Controller.extend({
       var runningTime = 0;
       var interval = setInterval( () => {
          Ember.$(window).trigger('resize');
-         console.dir('tr');
          runningTime += 100;
          if ( runningTime > duration ) {
            clearInterval(interval);

--- a/app/styles/blocks/content.scss
+++ b/app/styles/blocks/content.scss
@@ -3,11 +3,6 @@
   position: relative;
   width: 100%;
 
-  svg {
-    pointer-events: none; // TODO: Find a way to ignore pointer events in IE<10
-    position: absolute;
-    top: 0;
-  }
 }
 
 .content_loading {
@@ -23,4 +18,10 @@
     @include transition(opacity);
     opacity: 1;
   }
+}
+
+.content_svg-overlay {
+  pointer-events: none; // TODO: Find a way to ignore pointer events in IE<10
+  position: absolute;
+  top: 0;
 }

--- a/app/styles/blocks/header.scss
+++ b/app/styles/blocks/header.scss
@@ -34,6 +34,7 @@
 }
 
 .header_main {
+  height: (3 * $g);
   padding: ($g / 2) 12em ($g / 2) (5 * $g); // Make room on right for header_aside
 }
 

--- a/app/styles/blocks/popup.scss
+++ b/app/styles/blocks/popup.scss
@@ -56,3 +56,8 @@
     margin-bottom: ($g / 2);
   }
 }
+
+.popup_sub-heading {
+  font-weight: bold;
+  margin-bottom: 0;
+}

--- a/app/templates/components/letter-header.hbs
+++ b/app/templates/components/letter-header.hbs
@@ -66,7 +66,7 @@
               <a href="{{content.brief_url}}" target="_blank">Leibniz, Gottfried Wilhelm: Sämtliche Schriften und Briefe</a>
             </h2>
             <p>Hrsg. v. Berlin-Brandenburgischen Akademie der Wissenschaften / Akademie der Wissenschaften zu Göttingen</p>
-            <h3 class="popup_pre-heading">{{t 'permaLink'}}</h3>
+            <h3 class="popup_sub-heading">{{t 'permaLink'}}</h3>
             <input class="popup_input" type="url" value="{{content.brief_url}}">
           {{/pop-up}}
         </div>

--- a/tests/integration/letter-json-load-test.js
+++ b/tests/integration/letter-json-load-test.js
@@ -14,7 +14,7 @@ module('Integration | Letter JSON load test', {
 
 test('Letter loaded and header rendered', function(assert) {
   assert.expect(2);
-  // TODO: Workaround: Lr soad a letter without fulltext or MathJax will make this test fail
+  // TODO: Workaround: Load a letter without fulltext or MathJax will make this test fail
   visit('/letter/l3746').then(function() {
     assert.ok(find('.header_sender .header_last-name').text().length > 0, 'Header contains sender\'s last name');
     assert.ok(find('.header_recipient .header_last-name').text().length > 0, 'Header contains recipients\'s last name');


### PR DESCRIPTION
Search for image references in transcript, load SVG from Solr and display
inline vector images.

- Apply class to SVG overlay for connectors
- Fix comment typo
- Remove console.dir that managed to slip through (whoops!)

TODO: Add tests

Resolves: ADWD-1934