### PR TITLE
Make hover effect for variants more discreet

### DIFF
--- a/app/styles/blocks/drag-handle.scss
+++ b/app/styles/blocks/drag-handle.scss
@@ -1,8 +1,8 @@
 $drag-handle-height: 3.5 * $u !default; // no unit
 
 .drag-handle {
+  bottom: 0;
   cursor: ew-resize;
-  height: 100%;
   margin-left: (-$g / 4);
   padding: ($g / 2) 0;
   position: absolute;

--- a/app/styles/blocks/transcript.scss
+++ b/app/styles/blocks/transcript.scss
@@ -29,8 +29,7 @@
     }
 
     &.-hover {
-      background: $link-hover-color;
-      color: auto-color($link-hover-color);
+      color: $link-color;
     }
 
     &.-highlight {

--- a/app/styles/blocks/variant.scss
+++ b/app/styles/blocks/variant.scss
@@ -12,8 +12,7 @@
   right: ($g / 2);
 
   &.-hover {
-    background: $link-hover-color;
-    color: auto-color($link-hover-color);
+    color: $link-color;
   }
 
   &.-highlight {


### PR DESCRIPTION
Additionally, prevent drag handle from being cut off when in topmost
position while metadata or citation is open.