### PR TITLE
Adjust variants lane height to always fit all variants

### DIFF
--- a/app/routes/letter.js
+++ b/app/routes/letter.js
@@ -167,7 +167,6 @@ export default Ember.Route.extend({
       var bottom = $this.position().top + $this.outerHeight();
 
       var variantTop = (top < prevVariantBottom ? prevVariantBottom : top);
-      prevVariantBottom = variantTop + $variant.outerHeight() + marginBetweenVariants;
       $variant.css( {top: variantTop} );
 
       // Draw a curved line from reference to variant
@@ -196,7 +195,11 @@ export default Ember.Route.extend({
       }, () => {
         $this.add($variant).removeClass('-hover');
       });
+
+      prevVariantBottom = variantTop + $variant.outerHeight() + marginBetweenVariants;
     });
+
+    $laneVariants.height(prevVariantBottom);
   }
 });
 


### PR DESCRIPTION
Prevent variants from being pushed out of the viewport when a letter
contains many at the end by adjusting the lane height after all
variants have been positioned.