### PR TITLE
Replace Sass spinners package with extend

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,7 +1,6 @@
 // TODO: Find a way to glob-import mixins and blocks
 
 @import 'bower_components/reset-css/_reset'; // Underscore is required to distinguish from reset.css
-@import 'bower_components/spinners/stylesheets/spinners';
 @import 'vendor/entypo-plus';
 
 @import 'util/functions';
@@ -23,6 +22,7 @@
 
 @import 'extends/header-aside';
 @import 'extends/popup';
+@import 'extends/spinner';
 
 @import 'util/base';
 @import 'util/modifiers';

--- a/app/styles/blocks/content.scss
+++ b/app/styles/blocks/content.scss
@@ -5,7 +5,7 @@
 }
 
 .content_loading {
-  @include spinner($g, border-color $alpha-color);
+  @extend %spinner;
   margin: $g;
 }
 

--- a/app/styles/extends/spinner.scss
+++ b/app/styles/extends/spinner.scss
@@ -1,0 +1,22 @@
+%spinner {
+  background-color: transparent;
+  border: $border-width-bold solid $alpha-color;
+  border-radius: 50%;
+  border-top-color: transparent;
+  border-right-color: transparent;
+  width: $g;
+  height: $g;
+  display: inline-block;
+  vertical-align: middle;
+  box-sizing: border-box;
+  animation: spinner-animation 0.6s infinite linear;
+}
+
+@keyframes spinner-animation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
Previously used package seems not to be working correctly with
current ember-cli-sass. Also, should shed a second from build time.