### PR TITLE
Remove top transition, fix variant connectors in Firefox

### DIFF
--- a/app/routes/letter.js
+++ b/app/routes/letter.js
@@ -189,12 +189,11 @@ export default Ember.Route.extend({
       var bottom = $this.position().top + $this.outerHeight();
 
       var variantTop = (top < prevVariantBottom ? prevVariantBottom : top);
-      $variant.css( {opacity: 1, top: variantTop} );
+      $variant.css( {top: variantTop} ).addClass('-visible');
 
       // Draw a curved line from reference to variant
       var path = document.createElementNS(svgNS, 'path');
-      // TODO: Use color from CSS only if in long hex format, short hex is not supported by SVG
-      var strokeColor = $variant.css('border-color').length < 66 ? $variant.css('border-color') : '#aaaaaa';
+      var strokeColor = $variant.css('border-left-color'); // This provides an SVG-compatible rgb(...) color value
       path.setAttribute('stroke', strokeColor);
       path.setAttribute('fill', 'none');
       path.setAttribute('style', 'stroke-width: 1px');

--- a/app/styles/blocks/variant.scss
+++ b/app/styles/blocks/variant.scss
@@ -1,8 +1,8 @@
 .variant {
   @extend %variant-colors;
   @include drop-shadow;
-  @include transition(color, background, opacity, top);
-  background: $white;
+  @include transition(color, background, opacity);
+  background: white;
   border-left: $border-width-bold $border-style $border-color-dark;
   border-radius: $br;
   cursor: pointer;
@@ -21,7 +21,11 @@
 
   &.-highlight {
     background: $text-color-light;
-    color: $white;
+    color: white;
+  }
+
+  &.-visible {
+    opacity: 1;
   }
 
   .eds {
@@ -48,6 +52,6 @@
 
   &.-dark {
     background: $shade-dark;
-    color: $white;
+    color: white;
   }
 }


### PR DESCRIPTION
Making variants fly in from the top can be annoying when toggling them in letters with many variants, so just fade in after positioning.

Resolves: ADWD-1984