### PR TITLE
Fix highlighting of references when toggling variants

### DIFF
--- a/app/components/lane-variants.js
+++ b/app/components/lane-variants.js
@@ -19,6 +19,10 @@ export default Ember.Component.extend({
         var toggleIndexedAndHasIndexedWitness = ( variant.textzeuge && variant.textzeuge[0] === witnessId );
         var toggleOtherAndHasOtherWitness = ( witnessId === 'other' && ! variant.witnessIndex );
         if ( toggleIndexedAndHasIndexedWitness || toggleOtherAndHasOtherWitness ) {
+          if ( variant.visible ) {
+            var $references = Ember.$('.lane.transcript').find(`[data-id=${variant.id}], [data-ref-id=${variant.id}]`);
+            $references.removeClass('-highlight');
+          }
           return Ember.set(variant, 'visible', ! variant.visible);
         }
       });

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "ember-qunit-notifications": "0.1.0",
     "ember-resolver": "~0.1.20",
     "jquery": "^1.11.3",
-    "loader.js": "ember-cli/loader.js#3.2.1",
+    "loader.js": "ember-cli/loader.js#3.3.0",
     "qunit": "~1.20.0",
     "reset-css": "~2.0.2011012602",
     "MathJax": "components/MathJax#~2.5.3",

--- a/tests/acceptance/toggle-variants-test.js
+++ b/tests/acceptance/toggle-variants-test.js
@@ -5,17 +5,26 @@ moduleForAcceptance('Acceptance | toggle variants test');
 
 // TODO: Make this test more elaborate
 test('toggle variants', function(assert) {
+  assert.expect(2);
+
   // Make sure this letter actually has variants
   visit('/letter/l3717');
 
   var variantsCount = 0
+  var highlightsCount = 0
+
+  // Highlight all variants
+  click('.variants .variant');
   andThen(function() {
     variantsCount = find('.variants .variant:visible').length;
+    highlightsCount = find('.transcript .reference.-highlight').length;
   })
 
   click('.variants .variants_button:first');
   andThen(function() {
-    var visibleVariants = find('.variants .variant:visible').length;
-    assert.ok(visibleVariants < variantsCount, 'some variants should be hidden');
+    var visibleVariantsCount = find('.variants .variant:visible').length;
+    var lessHighlightsCount = find('.transcript .reference.-highlight').length;
+    assert.ok(visibleVariantsCount < variantsCount, 'less variants should be visible');
+    assert.ok(lessHighlightsCount < highlightsCount, 'less references should be highlighted')
   });
 });


### PR DESCRIPTION
Remove highlight from associated reference when variant is hidden.

Update loader.js to get rid of deprecation notice, fix test file name.

Resolves: ADWD-2003