### PR TITLE
Fix scroll handler

### DIFF
--- a/app/mixins/scrolling.js
+++ b/app/mixins/scrolling.js
@@ -7,6 +7,7 @@ export default Ember.Mixin.create({
       var scrollPos = Ember.$(window).scrollTop();
       return this.scrolled(scrollPos);
     };
+    this.unbindScrolling();
     Ember.$(window).bind('scroll', onScroll);
     Ember.$(document).bind('touchmove', onScroll);
   },


### PR DESCRIPTION
Scroll handler was re-bound on every route change and thus fired
even for destroyed views, raising errors. Now bindings are being
reset first.