### PR TITLE
Load MathJax from CDN to fix production build

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -12,7 +12,6 @@
     <link rel="stylesheet" href="assets/leibniz-frontend.css">
     <link rel="stylesheet" href="assets/fontello/css/fontello.css">
 
-
     {{content-for 'head-footer'}}
   </head>
   <body>
@@ -20,7 +19,7 @@
 
     <script src="assets/vendor.js"></script>
     <script src="assets/leibniz-frontend.js"></script>
-    <script src="assets/MathJax/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 
     {{content-for 'body-footer'}}
   </body>

--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,6 @@
     "loader.js": "ember-cli/loader.js#3.4.0",
     "qunit": "~1.20.0",
     "reset-css": "~2.0.2011012602",
-    "MathJax": "components/MathJax#~2.6.0",
     "javascript-detect-element-resize": "~0.5.3"
   },
   "resolutions": {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -24,15 +24,9 @@ module.exports = function(defaults) {
   // along with the exports of each module as its value.
   app.import('bower_components/javascript-detect-element-resize/jquery.resize.js');
 
-
-  // Import MathJax via Funnel since there are sooo many components
-  var mathJax = new Funnel('bower_components/MathJax', {
-    destDir: '/assets/MathJax'
-  });
-
   var fontello = new Funnel('vendor/fontello', {
     destDir: '/assets/fontello'
   });
 
-  return app.toTree([mathJax, fontello]);
+  return app.toTree([fontello]);
 };

--- a/tests/index.html
+++ b/tests/index.html
@@ -28,7 +28,7 @@
     <script src="assets/test-support.js"></script>
     <script src="assets/leibniz-frontend.js"></script>
     <!-- Disabled MathJax in tests since runtime seems to be unpredictable -->
-    <!-- <script src="assets/MathJax/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script> -->
+    <!-- <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script> -->
     <script src="testem.js" integrity=""></script>
     <script src="assets/tests.js"></script>
     <script src="assets/test-loader.js"></script>


### PR DESCRIPTION
Installing MathJax locally was too much for ember-cli and made the
production build fail.