### PR TITLE
WIP: Add bibliographic data, display child variants

### DIFF
--- a/app/components/pop-up.js
+++ b/app/components/pop-up.js
@@ -5,14 +5,14 @@ export default Ember.Component.extend({
   tagName: 'span',
   didInsertElement() {
     var $this = this.$();
-    var $parent = $this.parent();
-    $parent.css('position', 'relative');
-    if ( $parent.offset().left > 0.5 * Ember.$(window).width() ) {
-      $this.addClass('-right');
+    $this.parent().css('position', 'relative');
+    var newWidth = ( $this.outerHeight() + $this.outerWidth() ) / 2.5;
+    if ( newWidth > $this.outerWidth() ) {
+      $this.width(newWidth);
     }
-    var newMinWidth = $this.height();
-    if ( newMinWidth > $this.width() ) {
-      $this.css({ minWidth: newMinWidth });
+    var right = Ember.$(window).width() - $this.offset().left - $this.outerWidth() - 10;
+    if ( right < 0 ) {
+      $this.width( $this.width() + right );
     }
   }
 });

--- a/app/routes/letter.js
+++ b/app/routes/letter.js
@@ -57,14 +57,29 @@ export default Ember.Route.extend(Solr, {
     controller.set('rendered', true);
   },
   afterModel() {
+    var $ = Ember.$;
+
     Ember.run.next( () => {
       this.activateLinks();
 
+      // Add bibliographic info popups
+      $('.metadata').find('.reference.-biblio').each( (index, ref) => {
+        var id = $(ref).data('href');
+        this.loadBiblio(id).then( function(html) {
+          // TODO: This is not an instance of "pop-up" component, but merely
+          // a dumb DOM node with he same class name. Therefore, position and
+          // size are not adjusted automatically.
+          var $popup = $('<span class="pop-up -wide -right"/>');
+          $popup.html(html);
+          $(ref).css('position', 'relative').append($popup);
+        });
+      });
+
       // Convert image references to SVG images
-      Ember.$('.transcript, .variants').find('.reference.-image').each( (index, ref) => {
-        var imageID = Ember.$(ref).data('id');
-        this.loadSVG(imageID).then( function(svg) {
-          Ember.$(ref).html(svg);
+      $('.transcript, .variants').find('.reference.-image').each( (index, ref) => {
+        var id = $(ref).data('id');
+        this.loadSVG(id).then( function(svg) {
+          $(ref).html(svg);
         });
       });
 
@@ -72,7 +87,7 @@ export default Ember.Route.extend(Solr, {
       this.renderMathJax().then( () => {
         // TODO: For some reason, resize is always triggered once
         // this.positionVariants();
-        Ember.$('.lane').resize( () => {
+        $('.lane').resize( () => {
           Ember.run.debounce(this, this.clearVariantConnectors, 333, true);
           Ember.run.debounce(this, this.positionVariants, 333);
         });
@@ -90,10 +105,19 @@ export default Ember.Route.extend(Solr, {
       route.transitionTo('letter', letterID);
     });
   },
+  loadBiblio(id) {
+    return new Ember.RSVP.Promise( (resolve) => {
+      this.query(`id:${id}`).then( function(json) {
+        if ( json.response.docs.length > 0 && json.response.docs[0].hasOwnProperty('bibliographische_angabe') ) {
+          resolve(json.response.docs[0].bibliographische_angabe);
+        }
+      });
+    });
+  },
   loadSVG(id) {
     return new Ember.RSVP.Promise( (resolve) => {
       this.query(`id:${id}`).then( function(json) {
-        if ( json.response.docs.length > 0 && json.response.docs[0].hasOwnProperty('svg_code')) {
+        if ( json.response.docs.length > 0 && json.response.docs[0].hasOwnProperty('svg_code') ) {
           resolve(json.response.docs[0].svg_code);
         }
       });
@@ -116,18 +140,18 @@ export default Ember.Route.extend(Solr, {
   },
   positionVariants() {
     var $ = Ember.$;
-    var $laneTranscript = $('.transcript');
-    var $references = $laneTranscript.find('.reference');
+    var $transcriptLane = $('.transcript');
+    var $references = $transcriptLane.find('.reference.-afootnote, .reference.-cfootnote');
 
     this.clearVariantConnectors();
     if ( $references.length === 0 ) {
       return;
     }
 
-    var $laneVariants = $('.variants');
-    var $laneHeader = $laneVariants.find('.lane_header');
-    var $variants = $laneVariants.find('.variant');
-    var marginBetweenVariants = parseInt( $laneVariants.css('line-height') ) / 2;
+    var $variantsLane = $('.variants');
+    var $laneHeader = $variantsLane.find('.lane_header');
+    var $variants = $variantsLane.find('.variant');
+    var marginBetweenVariants = parseInt( $variantsLane.css('line-height') ) / 2;
     var prevVariantBottom = $laneHeader.position().top + $laneHeader.outerHeight();
     // NOTE: Shorthand css properties like `padding` are not supported in Firefox
 
@@ -144,7 +168,7 @@ export default Ember.Route.extend(Solr, {
       var variantID = $this.data('id');
       var $variant = $variants.filter('#' + variantID);
       if ( $variant.length === 0 ) {
-        return; // variant not available
+        return; // no variant with this ID
       }
       var left = $this.position().left;
       var top = $this.position().top;
@@ -162,9 +186,9 @@ export default Ember.Route.extend(Solr, {
       path.setAttribute('style', 'stroke-width: 1px');
       // 14: padding right of .lane_content
       var pathD = `M ${left + 3}, ${bottom - .5}
-                   L ${$laneTranscript.width() - 14}, ${bottom - .5}
-                   C ${$laneTranscript.width()}, ${bottom - .5},
-                     ${$laneTranscript.width()}, ${variantTop + $variant.outerHeight() / 2 - .5},
+                   L ${$transcriptLane.width() - 14}, ${bottom - .5}
+                   C ${$transcriptLane.width()}, ${bottom - .5},
+                     ${$transcriptLane.width()}, ${variantTop + $variant.outerHeight() / 2 - .5},
                      ${$variant.offset().left}, ${variantTop + $variant.outerHeight() / 2 - .5}`;
       path.setAttribute('d', pathD);
       svg.appendChild(path);
@@ -185,9 +209,18 @@ export default Ember.Route.extend(Solr, {
       });
 
       prevVariantBottom = variantTop + $variant.outerHeight() + marginBetweenVariants;
+
+      // TODO: Child variants / variants in variants
+      var $childReferences = $variant.find('.reference.-afootnote, .reference.-cfootnote');
+      $childReferences.each( function() {
+        var childVariantID = $(this).data('id');
+        var $childVariant = $variants.filter('#' + childVariantID);
+        $childVariant.css( {top: prevVariantBottom, marginLeft: '30px' /* TODO: use class instead */} ).addClass('-visible');
+        prevVariantBottom += $childVariant.outerHeight() + marginBetweenVariants;
+      });
     });
 
-    $laneVariants.height(prevVariantBottom);
+    $variantsLane.height(prevVariantBottom);
   }
 });
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -15,12 +15,11 @@
 @import 'mixins/header-button';
 @import 'mixins/hover';
 @import 'mixins/icon';
-@import 'mixins/link-border-on-hover';
-@import 'mixins/link-border';
 @import 'mixins/placeholder-color';
 @import 'mixins/transition';
 @import 'mixins/typo-scale';
 
+@import 'extends/caption';
 @import 'extends/header-aside';
 @import 'extends/popup';
 @import 'extends/spinner';
@@ -47,4 +46,3 @@
 @import 'blocks/transcript';
 @import 'blocks/variant';
 @import 'blocks/variants';
-

--- a/app/styles/blocks/lane-type.scss
+++ b/app/styles/blocks/lane-type.scss
@@ -4,8 +4,8 @@
 }
 
 .lane-type_toggle {
+  @extend %caption;
   @include transition(color);
-  color: $text-color-light;
   display: inline-block;
 }
 

--- a/app/styles/blocks/metadata.scss
+++ b/app/styles/blocks/metadata.scss
@@ -1,8 +1,12 @@
 .metadata {
   @extend %header-aside;
-  
+
   .caps {
     text-transform: capitalize;
+  }
+
+  .reference.-biblio {
+    border-bottom: $border-width dotted;
   }
 }
 

--- a/app/styles/blocks/transcript.scss
+++ b/app/styles/blocks/transcript.scss
@@ -1,10 +1,6 @@
 .transcript {
   @extend %lane;
 
-  a {
-    @include link-border;
-  }
-
   p {
     text-indent: $g;
   }
@@ -16,7 +12,7 @@
   .middleindent {
     text-indent: (1.5 * $g);
   }
-  
+
   .to-space {
     letter-spacing: 0.35em;
   }

--- a/app/styles/extends/caption.scss
+++ b/app/styles/extends/caption.scss
@@ -1,0 +1,8 @@
+%caption {
+  color: $text-color-light;
+  font-family: helvetica, arial, sans-serif;
+  text-transform: uppercase;
+  font-weight: bold;
+  letter-spacing: .05em;
+  font-size: .75em;
+}

--- a/app/styles/extends/header-aside.scss
+++ b/app/styles/extends/header-aside.scss
@@ -23,8 +23,4 @@
   ul {
     margin: 0;
   }
-
-  a {
-    @include link-border;
-  }
 }

--- a/app/styles/extends/popup.scss
+++ b/app/styles/extends/popup.scss
@@ -8,7 +8,7 @@
   font-style: normal;
   left: 0;
   margin: ($g / 4) 0 0;
-  min-width: 12em;
+  min-width: 6em;
   opacity: 0;
   padding: ($g / 4) ($g / 2);
   pointer-events: none; // TODO: This is not supported in IE<11
@@ -37,6 +37,10 @@
       left: auto;
       right: ($g / 2);
     }
+  }
+
+  &.-wide {
+    min-width: 12em;
   }
 }
 

--- a/app/styles/mixins/link-border-on-hover.scss
+++ b/app/styles/mixins/link-border-on-hover.scss
@@ -1,7 +1,0 @@
-@mixin link-border-on-hover {
-  border-bottom: $border-width $border-style transparent;
-
-  @include hover {
-    border-color: $link-hover-color;
-  }
-}

--- a/app/styles/mixins/link-border.scss
+++ b/app/styles/mixins/link-border.scss
@@ -1,7 +1,0 @@
-@mixin link-border {
-  border-bottom: $border-width $border-style $border-color;
-
-  @include hover {
-    border-color: $link-hover-color;
-  }
-}

--- a/config/environment.js
+++ b/config/environment.js
@@ -8,7 +8,7 @@ module.exports = function(environment) {
     contentSecurityPolicy: {
       'default-src': "'none'",
       'script-src': "*",
-      'font-src': "'self'",
+      'font-src': "*",
       'connect-src': "*",
       'img-src': "'self' data:",
       'style-src': "'self' 'unsafe-inline'",


### PR DESCRIPTION
 WIP: Add bibliographic data, display child variants

This is a work in progress adding two major features:

1. Loading and displaying of bibliographic data

   This should be complete, but is untested.

2. Displaying child variants (aka footnotes in footnotes)

   Child variants are displayed at the correct position, but
   neither is the reference in the parent highlighted, nor
   is a connector line drawn.

Your mission, should you choose to accept it, is to firstly
rebase this branch onto develop after all open pull requests
have been merged (there shouldn't be any conflicts).

Then add the missing features along with E2E tests, create new
branches and split the code into as many commits as reasonable.
When done, delete this branch - do not merge directly.

As always, should you or any of your team be caught or killed,
the Secretary will disavow any knowledge of your actions.
This message will self-destruct in five seconds. Good luck.