### PR TITLE
Prevent MathJax blocks in references from disappearing when highlighted

### DIFF
--- a/app/styles/blocks/transcript.scss
+++ b/app/styles/blocks/transcript.scss
@@ -42,6 +42,11 @@
     &.-highlight {
       background: $text-color-light;
       color: white;
+
+      .math {
+        background: $text-color-light;
+        border-radius: $br;
+      }
     }
 
     &.-image {


### PR DESCRIPTION
Resolves: ADWD-2223