### PR TITLE
Preserve rendered MathJax and SVG images when toggling variants

### DIFF
--- a/app/templates/components/lane-variants.hbs
+++ b/app/templates/components/lane-variants.hbs
@@ -34,9 +34,9 @@
   {{#each content.variants as |variant|}}
     {{#if variant.visible}}
       <div class="variant {{if variant.witnessIndex (concat '-color' variant.witnessIndex)}}" id="{{variant.id}}">
-
-        {{{variant.text_schnipsel}}}
-
+        <span class="variant_content">
+          {{{variant.text_schnipsel}}}
+        </span>
         <span class="variant_type {{if (eq variant.type 'note') '-dark'}}">
           {{t variant.type}}
         </span>

--- a/tests/acceptance/toggle-variants-test.js
+++ b/tests/acceptance/toggle-variants-test.js
@@ -5,20 +5,23 @@ moduleForAcceptance('Acceptance | toggle variants test');
 
 // TODO: Make this test more elaborate
 test('toggle variants', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
 
-  // Make sure this letter actually has variants
-  visit('/');
+  // Make sure this letter actually has variants with formulas and images
+  visit('/letter/l36137');
 
   var variantsCount = 0
   var highlightsCount = 0
 
-  // Highlight all variants
-  click('.variants .variant');
   andThen(function() {
     variantsCount = find('.variants .variant:visible').length;
+  });
+
+  // Highlight all variants
+  click('.variants .variant');
+  andThen(function () {
     highlightsCount = find('.transcript .reference.-highlight').length;
-  })
+  });
 
   click('.variants .variants_button');
   andThen(function() {
@@ -26,5 +29,14 @@ test('toggle variants', function(assert) {
     var lessHighlightsCount = find('.transcript .reference.-highlight').length;
     assert.ok(visibleVariantsCount < variantsCount, 'less variants should be visible');
     assert.ok(lessHighlightsCount < highlightsCount, 'less references should be highlighted')
+  });
+
+  // Restore all variants, check images
+  // NOTE: MathJax is disabled in test environment for performance reasons, so MathJax-rendered
+  // content cannot checked. Yet, if SVG is present, so should MathJax.
+  click('.variants .variants_button');
+  andThen(function() {
+    var imagesCount = find('.variants .reference.-image svg').length;
+    assert.ok(imagesCount > 0, 'SVG images should still be present');
   });
 });


### PR DESCRIPTION
Ensuring all images are loaded and MathJax is rendered, then overwrite
variant contents with current state. Updating test to check for images.

Resolves: ADWD-2226